### PR TITLE
Tenative fix for Weaponcore anhialating terminal controls

### DIFF
--- a/Aristeas_copy to DS and client.bat
+++ b/Aristeas_copy to DS and client.bat
@@ -1,0 +1,31 @@
+@echo off
+rem	Testing mods in DS by yourself can be done without the need to re-publish every time.
+rem	You can simply update the files that are on your machine!
+rem	This will only work for you, anyone else joining the server will of course download the mod from the workshop.
+
+rem	To use:
+rem	1. Copy this .bat file in the ROOT folder of your local mod (e.g. %appdata%/SpaceEngineers/Mods/YourLocalMod/<HERE>)
+
+rem	2. Edit this variable if applicable (do not add quotes or end with backslash).
+set STEAM_PATH=C:\Program Files (x86)\Steam
+
+rem	3. Edit this with your mod's workshop id.
+set WORKSHOP_ID=3149625043
+
+rem	Now you can run it every time you want to update the mod on DS and client.
+
+
+
+rem 	Don't edit the below unless you really need different paths.
+rem	NOTE: don't add quotes and don't end with a backslash!
+
+set CLIENT_PATH=%STEAM_PATH%\steamapps\workshop\content\244850\%WORKSHOP_ID%
+set DS_PATH=%APPDATA%\SpaceEngineersDedicated\content\244850\%WORKSHOP_ID%
+
+rmdir "%CLIENT_PATH%" /S /Q
+rmdir "%DS_PATH%" /S /Q
+
+robocopy.exe .\ "%DS_PATH%"  *.* /S /xd .git bin obj .vs ignored /xf *.lnk *.git* *.bat *.zip *.7z *.blend* *.md *.log *.sln *.csproj *.csproj.user *.ruleset modinfo.sbmi
+robocopy.exe "%DS_PATH%" "%CLIENT_PATH%" *.* /S
+
+pause

--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -149,6 +149,7 @@ namespace CoreSystems.Api
                 ["SetAreaRadiusMultiplier"] = new Action<MyEntity, float>(SetAreaRadiusMultiplier),
                 ["SetVelocityMultiplier"] = new Action<MyEntity, float>(SetVelocityMultiplier),
                 ["SetFiringAllowed"] = new Action<MyEntity, bool>(SetFiringAllowed),
+                ["RegisterTerminalControl"] = new Action<string>(RegisterTerminalControl),
 
                 ["GetRofMultiplier"] = new Func<MyEntity, float>(GetRofMultiplier),
                 ["GetBaseDmgMultiplier"] = new Func<MyEntity, float>(GetBaseDmgMultiplier),
@@ -402,6 +403,12 @@ namespace CoreSystems.Api
                 return false;
 
             return comp.Data.Repo.Values.Set.FiringAllowed;
+        }
+
+        private void RegisterTerminalControl(string controlId)
+        {
+            if (!Session.VisibleControls.Contains(controlId))
+                Session.VisibleControls.Add(controlId);
         }
 
         private void GetObstructionsLegacy(IMyEntity shooter, ICollection<IMyEntity> collection) => GetObstructions((MyEntity) shooter, (ICollection<MyEntity>) collection);

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -99,6 +99,7 @@ namespace CoreSystems.Api
         private Action<MyEntity, float> _setAreaRadiusMultiplier;
         private Action<MyEntity, float> _setVelocityMultiplier;
         private Action<MyEntity, bool> _setFiringAllowed;
+        private Action<string> _registerTerminalControl;
 
         private Func<MyEntity, float> _getRofMultiplier;
         private Func<MyEntity, float> _getBaseDmgMultiplier;
@@ -150,6 +151,13 @@ namespace CoreSystems.Api
         /// <param name="block"></param>
         /// <param name="multiplier"></param>
         public void SetFiringAllowed(MyEntity block, bool isAllowed) => _setFiringAllowed?.Invoke(block, isAllowed);
+
+        /// <summary>
+        /// Registers a terminal control to not be hidden by WeaponCore.
+        /// </summary>
+        /// <param name="block"></param>
+        /// <param name="multiplier"></param>
+        public void RegisterTerminalControl(string controlId) => _registerTerminalControl?.Invoke(controlId);
 
         public void SetWeaponTarget(MyEntity weapon, MyEntity target, int weaponId = 0) =>
             _setWeaponTarget?.Invoke(weapon, target, weaponId);
@@ -639,6 +647,7 @@ namespace CoreSystems.Api
             AssignMethod(delegates, "SetAreaRadiusMultiplier", ref _setAreaRadiusMultiplier);
             AssignMethod(delegates, "SetVelocityMultiplier", ref _setVelocityMultiplier);
             AssignMethod(delegates, "SetFiringAllowed", ref _setFiringAllowed);
+            AssignMethod(delegates, "RegisterTerminalControl", ref _registerTerminalControl);
 
             AssignMethod(delegates, "GetRofMultiplier", ref _getRofMultiplier);
             AssignMethod(delegates, "GetBaseDmgMultiplier", ref _getBaseDmgMultiplier);

--- a/Data/Scripts/CoreSystems/Session/SessionControls.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionControls.cs
@@ -463,7 +463,7 @@ namespace CoreSystems
             }
         }
 
-        private static HashSet<string> _visibleControls = new HashSet<string> 
+        public static HashSet<string> VisibleControls = new HashSet<string> 
         {
                 "OnOff",
                 //"Shoot",
@@ -596,7 +596,7 @@ namespace CoreSystems
                 var c = controls[i];
                 if (session.AlteredControls.Contains(c)) continue;
 
-                if (!_visibleControls.Contains(c.Id)) {
+                if (!VisibleControls.Contains(c.Id)) {
                     c.Visible = TerminalHelpers.NotWcBlock;
                     session.AlteredControls.Add(c);
                     continue;
@@ -726,8 +726,8 @@ namespace CoreSystems
                 c.Visible = null;
             }
             session.AlteredControls.Clear();
-            _visibleControls.Clear();
-            _visibleControls = null;
+            VisibleControls.Clear();
+            VisibleControls = null;
         }
 
         private static void EmptyAction(IMyTerminalBlock obj)


### PR DESCRIPTION
Seems to be related to load order? All non-WC options disappear, OR the custom terminal action is not displayed.